### PR TITLE
修复分栏阅读设置未生效的问题

### DIFF
--- a/src/CleanReader.App/Pages/ReaderPage.xaml.cs
+++ b/src/CleanReader.App/Pages/ReaderPage.xaml.cs
@@ -175,7 +175,7 @@ namespace CleanReader.App.Pages
                 _viewModel.Background,
                 _viewModel.Foreground,
                 _viewModel.AdditionalStyle);
-            await Reader.SetOptionsAsync(isSmoothScroll: _viewModel.IsSmoothScroll);
+            await Reader.SetOptionsAsync(minSpreadWidth: _viewModel.SpreadMinWidth, isSmoothScroll: _viewModel.IsSmoothScroll);
         }
 
         private async void OnRequestChangeChapterAsync(object sender, Models.App.ReaderChapter e)


### PR DESCRIPTION
<!-- 🚨 Please do not skip or delete the following information, they are all information required for assessment and testing, complete filling will help you pass the review faster 🚨 -->

<!-- 👉 A PR is best to address only one issue, unless those issues are related to each other -->

<!-- 📝 Please always open the PR `☑️ Allow edits by maintainers` button，Clean reader uses a stricter project template, and the maintainer can help you fix some minor errors or formatting issues 🎉 -->

## Close #20

正如 @noliar 所说，未在方法调用时传入设置的分栏阅读宽度，导致设置未生效

## PR type

What is the purpose of this PR?

<!-- Please uncomment the corresponding type -->

- Bug fix
<!-- - Feature -->
<!-- - Code style -->
<!-- - Build or CI update -->
<!-- - Document update -->
<!-- - Others： -->

## What is the current behavior?

设置分栏阅读宽度不生效

## What is the new behavior?

分栏阅读宽度设置生效

## PR checklist

Please check that your PR meets the following requirements: <!-- remove those that don't apply to the current PR -->

- [x] App successfully launched
- [x] File headers have been added to all source files
- [x] **NOT** Contains breaking updates

<!-- If this PR contains a breaking update, please describe below the impact on existing applications and how to adapt to the new changes -->

## Remark

<!-- Please add any information you find helpful -->
