### PR TITLE
修复拆分TXT时最后一章缺失的问题

### DIFF
--- a/src/Services/EpubService/EpubService.Constants.cs
+++ b/src/Services/EpubService/EpubService.Constants.cs
@@ -11,7 +11,7 @@ namespace CleanReader.Services.Epub
     {
         private const string MIME_TYPE = "application/epub+zip";
 
-        private static readonly Regex CHAPTER_DIVISION_REGEX = new (@"(正文){0,1}(\s|\n)(第)([\u4e00-\u9fa5a-zA-Z0-9]{1,7})[章节卷集部篇回幕计](\s{0})(.*)($\s*)");
+        private static readonly Regex CHAPTER_DIVISION_REGEX = new (@"^[ 　\t]{0,4}(?:序章|楔子|正文(?!完|结)|终章|后记|尾声|番外|第?\s{0,4}[\d〇零一二两三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟]+?\s{0,4}(?:章|节(?!课)|卷|集(?![合和])|部(?![分赛游])|篇(?!张))).{0,30}$");
         private static readonly string[] CHAPTER_EXTRA_KEYS = new string[] { "序", "前言", "后记", "楔子", "附录", "外传" };
 
         /// <summary>

--- a/src/Services/EpubService/EpubService.Txt.cs
+++ b/src/Services/EpubService/EpubService.Txt.cs
@@ -27,12 +27,7 @@ namespace CleanReader.Services.Epub
 
         private static bool IsExtra(string line)
         {
-            if (line.Length > MAX_CHAPTER_TITLE_LENGTH)
-            {
-                return false;
-            }
-
-            return CHAPTER_EXTRA_KEYS.Any(k => line.StartsWith(k));
+            return line.Length > MAX_CHAPTER_TITLE_LENGTH ? false : CHAPTER_EXTRA_KEYS.Any(k => line.StartsWith(k));
         }
 
         private static async Task GenerateHtmlFromTxtAsync(string title, string[] lines, int index, string folderPath = "")

--- a/src/Services/EpubService/EpubService.cs
+++ b/src/Services/EpubService/EpubService.cs
@@ -37,10 +37,7 @@ namespace CleanReader.Services.Epub
         public static async Task<EpubServiceConfiguration> SplitTxtFileAsync(string filePath, Regex? splitRegex = null, CancellationTokenSource cancellationTokenSource = null)
         {
             ClearCache();
-            if (splitRegex == null)
-            {
-                splitRegex = CHAPTER_DIVISION_REGEX;
-            }
+            splitRegex ??= CHAPTER_DIVISION_REGEX;
 
             var file = new FileInfo(filePath);
             if (file.Exists)
@@ -104,9 +101,14 @@ namespace CleanReader.Services.Epub
                 lineAction.Complete();
                 await lineAction.Completion;
 
-                if (filterLines.Count > 0 && !string.IsNullOrEmpty(chapterTitle))
+                if (filterLines.Count > 0)
                 {
-                    await GenerateHtmlFromTxtAsync(chapterTitle, filterLines.ToArray(), chapterIndex);
+                    if (string.IsNullOrEmpty(lastTitle))
+                    {
+                        lastTitle = "Untitled";
+                    }
+
+                    await GenerateHtmlFromTxtAsync(lastTitle, filterLines.ToArray(), chapterIndex);
                 }
 
                 if (!Directory.Exists(GENERATE_FOLDER_PATH))
@@ -196,9 +198,14 @@ namespace CleanReader.Services.Epub
                     }
                 }
 
-                if (filterLines.Count > 0 && !string.IsNullOrEmpty(chapterTitle))
+                if (filterLines.Count > 0)
                 {
-                    result.Add(new Tuple<string, int>(chapterTitle, filterLines.Sum(p => p.Length)));
+                    if (string.IsNullOrEmpty(lastTitle))
+                    {
+                        lastTitle = "Untitled";
+                    }
+
+                    result.Add(new Tuple<string, int>(lastTitle, filterLines.Sum(p => p.Length)));
                 }
 
                 return result;


### PR DESCRIPTION
<!-- 🚨 Please do not skip or delete the following information, they are all information required for assessment and testing, complete filling will help you pass the review faster 🚨 -->

<!-- 👉 A PR is best to address only one issue, unless those issues are related to each other -->

<!-- 📝 Please always open the PR `☑️ Allow edits by maintainers` button，Clean reader uses a stricter project template, and the maintainer can help you fix some minor errors or formatting issues 🎉 -->

## Close #58 

修复拆分TXT时最后一章缺失的问题

## PR type

What is the purpose of this PR?

<!-- Please uncomment the corresponding type -->

- Bug fix
<!-- - Feature -->
<!-- - Code style -->
<!-- - Build or CI update -->
<!-- - Document update -->
<!-- - Others： -->

## What is the current behavior?

拆分txt小说时，因为使用了错误的标题变量，导致最后一章无法被添加到标题列表中

## What is the new behavior?

修复这个问题

## PR checklist

Please check that your PR meets the following requirements: <!-- remove those that don't apply to the current PR -->

- [x] App successfully launched
- [x] File headers have been added to all source files
- [x] **NOT** Contains breaking updates

<!-- If this PR contains a breaking update, please describe below the impact on existing applications and how to adapt to the new changes -->

## Remark

替换了默认的分章表达式
